### PR TITLE
Fixed an issue with the boundaries of Cyber Maze

### DIFF
--- a/2kki/config.json
+++ b/2kki/config.json
@@ -166,7 +166,7 @@
 			"else": "Butterfly Forest"
 		},
 		"0701": [
-			{ "title": "Cyber Maze", "coords": { "x1": 0, "y1": -1, "x2": 40, "y2": -1 } },
+			{ "title": "Cyber Maze", "coords": { "x1": 0, "y1": -1, "x2": 52, "y2": -1 } },
 			"Dream Mexico"
 		],
 		"0708": [


### PR DESCRIPTION
Fixed an issue where going back from the corridor with the Cocktail Lounge would incorrectly list the player as Dream Mexico instead of Cyber Maze.