### PR TITLE
Fixing double Mechanics Halls

### DIFF
--- a/amillusion/config.json
+++ b/amillusion/config.json
@@ -209,7 +209,7 @@
 		"0209": "Ski Resort",
 		"0210": "Ski Resort",
 		"0211": { "title": "Science Museum: Mechanics Hall", "urlTitle": "Science_Museum#Mechanics_Hall" },
-		"0212": { "title": "Science Museum: Mechanics Hall", "urlTitle": "Science_Museum#Astronomy_Hall" },
+		"0212": { "title": "Science Museum: Astronomy Hall", "urlTitle": "Science_Museum#Astronomy_Hall" },
 		"0213": "Ski Resort",
 		"0214": "Ski Resort",
 		"0215": "Science Museum",


### PR DESCRIPTION
Likely uncaught due to somewhat hasty copy-pasting when adding wiki support.