### PR TITLE
Tsushin - Change the location of the hidden planet to be part of Moon

### DIFF
--- a/tsushin/config.json
+++ b/tsushin/config.json
@@ -100,7 +100,7 @@
         "0097": { "title": "Throne of Entrails", "urlTitle": "Events#Throne_of_Entrails" },
         "0098": "Moon",
         "0099": "Underpass",
-        "0100": "Dark Screaming Maze",
+        "0100": "Moon",
         "0101": "White Desert",
         "0102": "Cubic Lamp Meadow",
         "0104": "Monitor Realm",


### PR DESCRIPTION
In 0.00+a it used to be in the Dark Screaming Maze, while now it is between Moon and Head Space, and it looks more like Moon than Head Space, so the location needs to be updated this way.