### PR TITLE
remove (2kki) leo palace

### DIFF
--- a/2kki/config.json
+++ b/2kki/config.json
@@ -1030,7 +1030,6 @@
 		"1796": "Nocturne",
 		"1798": "Fox Temple",
 		"1801": { "title": "Rainbow Pottery Zone: Dogū World", "urlTitle": "Rainbow_Pottery_Zone#Dogū_World" },
-		"1802": { "title": "Rainbow Pottery Zone: Leo Palace", "urlTitle": "Rainbow_Pottery_Zone#Leo_Palace" },
 		"1805": [
 			{ "title": "Serpentine Pyramid", "coords": { "x1": 0, "y1": -1, "x2": 214, "y2": -1 } },
 			"Toxicology Research Facility"


### PR DESCRIPTION
this subarea has been moved to be a separate world, and now the desync between the wiki and this entry causes issues with expeds and location completion