### PR TITLE
Updated "Tapir-san's Place" capitalization

### DIFF
--- a/2kki/config.json
+++ b/2kki/config.json
@@ -40,7 +40,7 @@
 		"0059": { "title": "Japan Town: The Underground Bar", "urlTitle": "Japan_Town#The_Underground_Bar" },
 		"0060": [
 			{ "title": "Forest World", "coords": { "x1": 66, "y1": 0, "x2": 105, "y2": 65 } },
-			"Tapir-San's Place"
+			"Tapir-san's Place"
 		],
 		"0062": [
 			{ "title": "Highway", "coords": { "x1": -1, "y1": 0, "x2": -1, "y2": 108 } },


### PR DESCRIPTION
The wiki page's title was updated to reflect the capitalization used for the character (i.e. lowercase "san")