### PR TITLE
Update Trophy Room link

### DIFF
--- a/2kki/config.json
+++ b/2kki/config.json
@@ -128,7 +128,7 @@
 		],
 		"0177": "Urotsuki's Dream Apartments",
 		"0178": "Urotsuki's Dream Apartments",
-		"0179": "Trophy Room",
+		"0179": { "title": "Urotsuki's Dream Apartments: Trophy Room", "urlTitle": "Urotsuki%27s_Dream_Apartments#Trophy_Room" },
 		"0183": { "title": "Monochrome Feudal Japan: Monochrome Path", "urlTitle": "Monochrome_Feudal_Japan#Monochrome_Path" },
 		"0184": { "title": "Monochrome Feudal Japan: Monochrome Path", "urlTitle": "Monochrome_Feudal_Japan#Monochrome_Path" },
 		"0185": { "title": "Monochrome Feudal Japan: Monochrome Path", "urlTitle": "Monochrome_Feudal_Japan#Monochrome_Path" },


### PR DESCRIPTION
The Trophy Room page was recently made into a subsection of Urotsuki's Dream Apartments on the wiki